### PR TITLE
Add retry mechanism and more detailed logging for connection issues

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -79,6 +79,12 @@ abstract class PdoAdapter
             $con = new PdoConnection($dsn, $user, $password, $driverOptions);
             $this->initConnection($con, isset($params['settings']) && is_array($params['settings']) ? $params['settings'] : []);
         } catch (PDOException $e) {
+            // Detailed error logging
+            error_log(sprintf('PDO Connection Error: DSN: %s, Error: %s, Code: %s', 
+                preg_replace('/password=.*?;/', 'password=***;', $dsn), 
+                $e->getMessage(), 
+                $e->getCode()
+            ));
             throw new AdapterException('Unable to open PDO connection', 0, $e);
         }
 


### PR DESCRIPTION
Attempt to fix https://github.com/yearbook/ybmv3/issues/5581

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Connection creation now delays up to ~200ms on failures and writes DSN-related details to error_log; retries could mask persistent misconfiguration briefly but do not change successful-path behavior.
> 
> **Overview**
> Adds **resilience and observability** around Propel opening database connections, plus a small **query hook typing** fix.
> 
> **Connection path:** `ConnectionFactory::create()` now retries up to **3 attempts** (initial + 2 retries) when the adapter throws `AdapterException`, with **100ms** between tries. Each failed attempt is written to **`error_log`**, and the final failure becomes a `ConnectionException` that mentions the attempt count and preserves the last underlying error.
> 
> **PDO layer:** On `PDOException` during connect, `PdoAdapter` logs DSN (with password masked), message, and code via **`error_log`** before wrapping in `AdapterException`.
> 
> **Unrelated fix:** `ModelCriteria::basePreUpdate()` / `preUpdate()` drop the `array` type hint on `$values` so behavior hooks can pass either an update array or a `Criteria` (e.g. ON DELETE SET NULL emulation), with PHPDoc updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3776f3784cbb4ee9d27d5009e2e551b089794da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->